### PR TITLE
Fix issue 8

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -170,7 +170,8 @@ class DNF:
     def requires(self, pkg):
         res = set()
         for p in pkg.requires:
-            provider = self.resolve_RPM(p.name, for_pkg=pkg)
+            full_requirement = " ".join((p.name, p.relation, p.version))
+            provider = self.resolve_RPM(full_requirement, for_pkg=pkg)
             if provider is None:
                 continue
             if pkg.sourcerpm is None and provider.sourcerpm is None:

--- a/lib.py
+++ b/lib.py
@@ -36,6 +36,7 @@ class DNF:
     def __init__(self):
         self.base = dnf.Base()
         self.base.conf.read()
+        self.base.conf.set_or_append_opt_value("install_weak_deps", "0")
         self.base.read_all_repos()
         self.base.repos.get_matching("*").disable()
         self.base.repos.get_matching("rawhide").enable()


### PR DESCRIPTION
The problem this should solve is a combination of two issues:
* including weak dependencies in transactions, and
* ignoring versions (so `python(abi)` can be resolved to python2.7 under certain circumstances)

Fixes: #8 